### PR TITLE
Refactor Docker services and update callback request

### DIFF
--- a/CallbackHandler.IntegrationTests/Common/DockerHelper.cs
+++ b/CallbackHandler.IntegrationTests/Common/DockerHelper.cs
@@ -53,10 +53,6 @@ namespace CallbackHandler.IntegrationTests.Common
             logger.Initialise(LogManager.GetLogger(scenarioName), scenarioName);
             LogManager.AddHiddenAssembly(typeof(NlogLogger).Assembly);
 
-            //DockerServices dockerServices = DockerServices.CallbackHandler | DockerServices.EstateManagement | DockerServices.EventStore |
-            //                                DockerServices.FileProcessor | DockerServices.MessagingService | DockerServices.SecurityService | DockerServices.SqlServer |
-            //                                DockerServices.TestHost | DockerServices.TransactionProcessor | DockerServices.TransactionProcessorAcl;
-
             DockerServices dockerServices = DockerServices.CallbackHandler | DockerServices.EventStore | DockerServices.SqlServer;
 
             this.TestingContext.DockerHelper = new DockerHelper();

--- a/CallbackHandler/Controllers/CallbackController.cs
+++ b/CallbackHandler/Controllers/CallbackController.cs
@@ -47,7 +47,7 @@ namespace CallbackHandler.Controllers
 
             CallbackCommands.RecordCallbackRequest request = new CallbackCommands.RecordCallbackRequest(callbackId,
                 JsonConvert.SerializeObject(depositCallback),
-                new[] { "EstateManagement" },
+                new[] { "TransactionProcessor" },
                 MessageFormat.JSON,
                 depositCallback.GetType().ToString(),
                 depositCallback.Reference);


### PR DESCRIPTION
Removed unused Docker services in `DockerHelper.cs` and simplified the configuration. Updated the service name in `CallbackController.cs` from `"EstateManagement"` to `"TransactionProcessor"` to align with the new processing focus.