### PR TITLE
Update deployment for Linux and upgrade Shared package

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Publish API
       if: ${{ github.event.release.prerelease == false }} 
-      run: dotnet publish "CallbackHandler\CallbackHandler.csproj" --configuration Release --output publishOutput -r win-x64 --self-contained
+      run: dotnet publish "CallbackHandler\CallbackHandler.csproj" --configuration Release --output publishOutput -r linux-x64 --self-contained
 
     - name: Build Release Package
       run: |
@@ -75,7 +75,7 @@ jobs:
         dotnet nuget push Nugets/CallbackHandler.CallbackMessage.DomainEvents.${{ steps.get_version.outputs.VERSION }}.nupkg --api-key ${{ secrets.PRIVATEFEED_APIKEY }} --source ${{ secrets.PRIVATEFEED_URL }} --skip-duplicate
 
   deploystaging:
-    runs-on: stagingserver
+    runs-on: [stagingserver, linux]
     needs: buildlinux
     environment: staging
     name: "Deploy to Staging"
@@ -85,30 +85,76 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: callbackhandler
-
-      - name: Remove existing  Windows service
+          path: /tmp/callbackhandler # Download to a temporary directory
+  
+      - name: Remove existing service (if applicable)
         run: |
-          $serviceName = "Transaction Processing - Callback Handler"
-          # Check if the service exists
-          if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
-            Stop-Service -Name $serviceName
-            sc.exe delete $serviceName
-          }
-
+          SERVICE_NAME="callbackhandler"
+          if systemctl is-active --quiet "$SERVICE_NAME"; then
+            echo "Stopping existing service..."
+            sudo systemctl stop "$SERVICE_NAME"
+          fi
+          if systemctl is-enabled --quiet "$SERVICE_NAME"; then
+            echo "Disabling existing service..."
+            sudo systemctl disable "$SERVICE_NAME"
+          fi
+          if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+            echo "Removing existing service unit file..."
+            sudo rm "/etc/systemd/system/${SERVICE_NAME}.service"
+            sudo systemctl daemon-reload
+          fi
+  
       - name: Unzip the files
         run: |
-          Expand-Archive -Path callbackhandler.zip -DestinationPath "C:\txnproc\transactionprocessing\callbackhandler" -Force
-      
-      - name: Install as a Windows service
+          sudo mkdir -p /opt/txnproc/transactionprocessing/callbackhandler
+          sudo unzip -o /tmp/callbackhandler/callbackhandler.zip -d /opt/txnproc/transactionprocessing/callbackhandler
+  
+      # IMPORTANT: Add a step to ensure the .NET runtime is installed on the server
+      # This assumes it's not already there. If your base image already has it, you can skip this.
+      - name: Install .NET Runtime
         run: |
-          $serviceName = "Transaction Processing - Callback Handler"
-          $servicePath = "C:\txnproc\transactionprocessing\callbackhandler\CallbackHandler.exe"
-                   
-          New-Service -Name $serviceName -BinaryPathName $servicePath -Description "Transaction Processing - CallbackHandler" -DisplayName "Transaction Processing - CallbackHandler" -StartupType Automatic
-          Start-Service -Name $serviceName  
+          # Example for Ubuntu. Adjust based on your .NET version (e.g., 8.0, 7.0)
+          # and if you need the SDK or just the runtime.
+          # This uses Microsoft's package repository for the latest versions.
+          wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt update
+          sudo apt install -y aspnetcore-runtime-9.0
+  
+      - name: Install and Start as a Linux service
+        run: |
+          SERVICE_NAME="callbackhandler"
+          # The WorkingDirectory is crucial for .NET apps to find appsettings.json and other files
+          WORKING_DIRECTORY="/opt/txnproc/transactionprocessing/callbackhandler"
+          DLL_NAME="CallbackHandler.dll" # Your application's DLL
+          SERVICE_DESCRIPTION="Transaction Processing - Callback Handler"
+  
+          # Create a systemd service file
+          echo "[Unit]" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Description=${SERVICE_DESCRIPTION}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "After=network.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Service]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          # IMPORTANT: Use 'dotnet' to run your DLL
+          echo "ExecStart=/usr/bin/dotnet ${WORKING_DIRECTORY}/${DLL_NAME}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WorkingDirectory=${WORKING_DIRECTORY}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Restart=always" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "User=youruser"   # IMPORTANT: Change to a dedicated, less privileged user
+          echo "Group=yourgroup" # IMPORTANT: Change to a dedicated, less privileged group
+          echo "Environment=ASPNETCORE_ENVIRONMENT=Production" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service # Example
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Install]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WantedBy=multi-user.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+  
+          # Reload systemd, enable, and start the service
+          sudo systemctl daemon-reload
+          sudo systemctl enable "$SERVICE_NAME"
+          sudo systemctl start "$SERVICE_NAME"
+          sudo systemctl status "$SERVICE_NAME" --no-pager # For debugging/verification  
 
   deployproduction:
-    runs-on: productionserver
+    runs-on: [productionserver, linux]
     needs: [buildlinux, deploystaging]
     environment: production
     name: "Deploy to Production"
@@ -118,28 +164,73 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: callbackhandler
-
+          path: /tmp/callbackhandler # Download to a temporary directory
+  
+      - name: Remove existing service (if applicable)
+        run: |
+          SERVICE_NAME="callbackhandler"
+          if systemctl is-active --quiet "$SERVICE_NAME"; then
+            echo "Stopping existing service..."
+            sudo systemctl stop "$SERVICE_NAME"
+          fi
+          if systemctl is-enabled --quiet "$SERVICE_NAME"; then
+            echo "Disabling existing service..."
+            sudo systemctl disable "$SERVICE_NAME"
+          fi
+          if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+            echo "Removing existing service unit file..."
+            sudo rm "/etc/systemd/system/${SERVICE_NAME}.service"
+            sudo systemctl daemon-reload
+          fi
+  
       - name: Unzip the files
         run: |
-          Expand-Archive -Path callbackhandler.zip -DestinationPath "C:\txnproc\transactionprocessing\callbackhandler" -Force
-      
-      - name: Remove existing  Windows service
+          sudo mkdir -p /opt/txnproc/transactionprocessing/callbackhandler
+          sudo unzip -o /tmp/callbackhandler/callbackhandler.zip -d /opt/txnproc/transactionprocessing/callbackhandler
+  
+      # IMPORTANT: Add a step to ensure the .NET runtime is installed on the server
+      # This assumes it's not already there. If your base image already has it, you can skip this.
+      - name: Install .NET Runtime
         run: |
-          $serviceName = "Transaction Processing - Callback Handler"
-          # Check if the service exists
-          if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
-            Stop-Service -Name $serviceName
-            sc.exe delete $serviceName
-          }      
-      - name: Install as a Windows service
+          # Example for Ubuntu. Adjust based on your .NET version (e.g., 8.0, 7.0)
+          # and if you need the SDK or just the runtime.
+          # This uses Microsoft's package repository for the latest versions.
+          wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt update
+          sudo apt install -y aspnetcore-runtime-9.0
+  
+      - name: Install and Start as a Linux service
         run: |
-          $serviceName = "Transaction Processing - Callback Handler"
-          $servicePath = "C:\txnproc\transactionprocessing\callbackhandler\CallbackHandler.exe"
-          
-          New-Service -Name $serviceName -BinaryPathName $servicePath -Description "Transaction Processing - CallbackHandler" -DisplayName "Transaction Processing - CallbackHandler" -StartupType Automatic
-          Start-Service -Name $serviceName
-
-    
+          SERVICE_NAME="callbackhandler"
+          # The WorkingDirectory is crucial for .NET apps to find appsettings.json and other files
+          WORKING_DIRECTORY="/opt/txnproc/transactionprocessing/callbackhandler"
+          DLL_NAME="CallbackHandler.dll" # Your application's DLL
+          SERVICE_DESCRIPTION="Transaction Processing - Callback Handler"
+  
+          # Create a systemd service file
+          echo "[Unit]" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Description=${SERVICE_DESCRIPTION}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "After=network.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Service]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          # IMPORTANT: Use 'dotnet' to run your DLL
+          echo "ExecStart=/usr/bin/dotnet ${WORKING_DIRECTORY}/${DLL_NAME}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WorkingDirectory=${WORKING_DIRECTORY}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Restart=always" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "User=youruser"   # IMPORTANT: Change to a dedicated, less privileged user
+          echo "Group=yourgroup" # IMPORTANT: Change to a dedicated, less privileged group
+          echo "Environment=ASPNETCORE_ENVIRONMENT=Production" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service # Example
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Install]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WantedBy=multi-user.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+  
+          # Reload systemd, enable, and start the service
+          sudo systemctl daemon-reload
+          sudo systemctl enable "$SERVICE_NAME"
+          sudo systemctl start "$SERVICE_NAME"
+          sudo systemctl status "$SERVICE_NAME" --no-pager # For debugging/verification              
 
   buildwindows:
     name: "Windows Release"

--- a/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
+++ b/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared.EventStore" Version="2025.6.1" />
+    <PackageReference Include="Shared.EventStore" Version="2025.6.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">

--- a/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
+++ b/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="12.5.0" />
-		<PackageReference Include="Shared" Version="2025.6.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.1" />
-		<PackageReference Include="Shared.EventStore" Version="2025.6.1" />
+		<PackageReference Include="Shared" Version="2025.6.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.2" />
+		<PackageReference Include="Shared.EventStore" Version="2025.6.2" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\CallbackHandler.CallbackMessageAggregate\CallbackHandler.CallbackMessageAggregate.csproj" />

--- a/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
+++ b/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
@@ -5,7 +5,7 @@
 		<DebugType>None</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared" Version="2025.6.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.1" />
+		<PackageReference Include="Shared" Version="2025.6.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.2" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
+++ b/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Shared.EventStore" Version="2025.6.1" />
+    <PackageReference Include="Shared.EventStore" Version="2025.6.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
+++ b/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
@@ -10,8 +10,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-		<PackageReference Include="Shared" Version="2025.6.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.1" />
-		<PackageReference Include="Shared.EventStore" Version="2025.6.1" />
+		<PackageReference Include="Shared" Version="2025.6.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.6.2" />
+		<PackageReference Include="Shared.EventStore" Version="2025.6.2" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
+++ b/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net9.0</TargetFramework>
@@ -15,8 +15,8 @@
 	  <PackageReference Include="NUnit" Version="4.3.2" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-	  <PackageReference Include="Shared" Version="2025.6.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.6.1" />
+	  <PackageReference Include="Shared" Version="2025.6.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler/CallbackHandler.csproj
+++ b/CallbackHandler/CallbackHandler.csproj
@@ -12,7 +12,7 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Shared" Version="2025.6.1" />
+    <PackageReference Include="Shared" Version="2025.6.2" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.2" />


### PR DESCRIPTION
Modified `createrelease.yml` to target Linux runtime, replacing Windows service management with systemd commands. Added steps for .NET runtime installation and service creation on Linux. Updated `Shared` package version from `2025.6.1` to `2025.6.2` across multiple project files, ensuring compatibility with the latest dependencies. Adjusted test project files to reflect the new package version.

closes #113