### PR TITLE
Update package references to version 2025.7.13

### DIFF
--- a/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
+++ b/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+    <PackageReference Include="Shared.EventStore" Version="2025.7.13" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">

--- a/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
+++ b/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="12.5.0" />
-		<PackageReference Include="Shared" Version="2025.7.10" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
-		<PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+		<PackageReference Include="Shared" Version="2025.7.13" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
+		<PackageReference Include="Shared.EventStore" Version="2025.7.13" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\CallbackHandler.CallbackMessageAggregate\CallbackHandler.CallbackMessageAggregate.csproj" />

--- a/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
+++ b/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
@@ -5,7 +5,7 @@
 		<DebugType>None</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared" Version="2025.7.10" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
+		<PackageReference Include="Shared" Version="2025.7.13" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
+++ b/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+    <PackageReference Include="Shared.EventStore" Version="2025.7.13" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
+++ b/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
@@ -10,8 +10,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-		<PackageReference Include="Shared" Version="2025.7.10" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
-		<PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+		<PackageReference Include="Shared" Version="2025.7.13" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
+		<PackageReference Include="Shared.EventStore" Version="2025.7.13" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
+++ b/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
@@ -15,8 +15,8 @@
 	  <PackageReference Include="NUnit" Version="4.3.2" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-	  <PackageReference Include="Shared" Version="2025.7.10" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.10" />
+	  <PackageReference Include="Shared" Version="2025.7.13" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler/CallbackHandler.csproj
+++ b/CallbackHandler/CallbackHandler.csproj
@@ -12,7 +12,7 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Shared" Version="2025.7.10" />
+    <PackageReference Include="Shared" Version="2025.7.13" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.2" />


### PR DESCRIPTION
Updated the version of several package references from `2025.7.10` to `2025.7.13` across multiple project files. This includes `Shared`, `Shared.DomainDrivenDesign`, `Shared.EventStore`, and `Shared.IntegrationTesting`. Changes were made in the following project files: `CallbackHandler.BusinessLogic.Tests.csproj`, `CallbackHandler.BusinessLogic.csproj`, `CallbackHandler.CallbackMessage.DomainEvents.csproj`, `CallbackHandler.CallbackMessageAggregate.Tests.csproj`, `CallbackHandler.CallbackMessageAggregate.csproj`, and `CallbackHandler.csproj`. These updates ensure all projects are using the latest versions of the shared libraries, which may include bug fixes, new features, or performance improvements.

closes #120 