### PR TITLE
Update NuGet package versions for Shared and test SDKs

### DIFF
--- a/CallbackHander.Testing/CallbackHander.Testing.csproj
+++ b/CallbackHander.Testing/CallbackHander.Testing.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
+++ b/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
+++ b/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="14.0.0" />
-		<PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+		<PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\CallbackHandler.CallbackMessageAggregate\CallbackHandler.CallbackMessageAggregate.csproj" />

--- a/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
+++ b/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
@@ -5,7 +5,7 @@
 		<DebugType>None</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared" Version="2026.2.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
+++ b/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
+++ b/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
@@ -10,8 +10,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
+++ b/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
@@ -15,13 +15,13 @@
 	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
 	  <PackageReference Include="NUnit" Version="4.5.0" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-	  <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.12.2" />
-	  <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+	  <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
+	  <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler.Tests/CallbackHandler.Tests.csproj
+++ b/CallbackHandler.Tests/CallbackHandler.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Lamar" Version="15.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/CallbackHandler/CallbackHandler.csproj
+++ b/CallbackHandler/CallbackHandler.csproj
@@ -12,8 +12,8 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />


### PR DESCRIPTION
Upgraded Shared, Shared.DomainDrivenDesign, and Shared.EventStore packages to 2026.2.2 across all projects. Updated Microsoft.NET.Test.Sdk to 18.3.0 in test projects. Also bumped SecurityService.Client, TransactionProcessor.Client, and related integration/testing helpers for consistency. No code changes, only dependency updates.

closes #229 