### PR TITLE
Make Sentry options configurable; clean up Startup.cs

### DIFF
--- a/CallbackHandler/Program.cs
+++ b/CallbackHandler/Program.cs
@@ -103,7 +103,8 @@ namespace CallbackHandler
                                                                      o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                      o.SendDefaultPii = true;
                                                                      o.MaxRequestBodySize = RequestSize.Always;
-                                                                     o.CaptureBlockingCalls = true;
+                                                                     o.CaptureBlockingCalls = bool.Parse(builtConfig["SentryConfiguration:CaptureBlockingCalls"]);
+                                                                     o.IncludeActivityData = bool.Parse(builtConfig["SentryConfiguration:IncludeActivityData"]);
                                                                      o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                                  });
                                                              }

--- a/CallbackHandler/Startup.cs
+++ b/CallbackHandler/Startup.cs
@@ -25,14 +25,6 @@ namespace CallbackHandler
     {
         public Startup(IWebHostEnvironment webHostEnvironment)
         {
-            //IConfigurationBuilder builder = new ConfigurationBuilder().SetBasePath(webHostEnvironment.ContentRootPath)
-            //                                                          .AddJsonFile("/home/txnproc/config/appsettings.json", true, true)
-            //                                                          .AddJsonFile($"/home/txnproc/config/appsettings.{webHostEnvironment.EnvironmentName}.json", optional: true)
-            //                                                          .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            //                                                          .AddJsonFile($"appsettings.{webHostEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true)
-            //                                                          .AddEnvironmentVariables();
-
-            //Startup.Configuration = builder.Build();
             Startup.WebHostEnvironment = webHostEnvironment;
         }
 


### PR DESCRIPTION
Sentry's CaptureBlockingCalls and IncludeActivityData options are now configurable via app settings instead of being hardcoded. Also, removed obsolete commented-out configuration code from Startup.cs for clarity.

closes #244 