### PR TITLE
Remove unit tests from release, add trace log uploads

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -24,13 +24,6 @@ jobs:
       - name: Build Code
         run: dotnet build CallbackHandler.sln --configuration Release
 
-      - name: Run Unit Tests
-        run: |
-          echo "ASPNETCORE_ENVIRONMENT is > ${ASPNETCORE_ENVIRONMENT}"
-          dotnet test "CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj"
-          dotnet test "CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj"
-          dotnet test "CallbackHandler.Tests/CallbackHandler.Tests.csproj"
-
       - name: Publish Docker Image - Pre Release
         if: ${{ github.event.release.prerelease == true }} 
         run: |

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -37,6 +37,11 @@ jobs:
 
     - name: Run Integration Tests
       run: dotnet test "CallbackHandler.IntegrationTests\CallbackHandler.IntegrationTests.csproj"
+
+    - uses: actions/upload-artifact@v4.4.0
+      with:
+        name: tracelogs
+        path: /home/runner/trace/ 
     
     - uses: dacbd/create-issue-action@main
       if: ${{ failure() }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,6 +35,11 @@ jobs:
     - name: Run Integration Tests
       run: dotnet test "CallbackHandler.IntegrationTests\CallbackHandler.IntegrationTests.csproj" --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
+    - uses: actions/upload-artifact@v4.4.0
+      with:
+        name: tracelogs
+        path: /home/runner/trace/ 
+
     - name: Publish test results
       uses: dorny/test-reporter@v1
       if: always()


### PR DESCRIPTION
Removed unit test execution from createrelease.yml. Added steps to nightlybuild.yml and pullrequest.yml to upload trace logs as artifacts after integration tests. In pullrequest.yml, trace logs are uploaded before publishing test results.

closes #248 