### PR TITLE
Update Shared and related NuGet packages to 2026.5.6

### DIFF
--- a/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
+++ b/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
+++ b/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="14.1.0" />
-		<PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-		<PackageReference Include="Shared" Version="2026.5.5" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.5" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build352" />
+		<PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
+		<PackageReference Include="Shared" Version="2026.5.6" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
+		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\CallbackHandler.CallbackMessageAggregate\CallbackHandler.CallbackMessageAggregate.csproj" />

--- a/CallbackHandler.BusinessLogic/Services/CallbackDomainService.cs
+++ b/CallbackHandler.BusinessLogic/Services/CallbackDomainService.cs
@@ -46,7 +46,6 @@ public class CallbackDomainService : ICallbackDomainService
         Result<(Guid estateId, Guid merchantId)> validateResult = await ValidateReference(command.Reference, cancellationToken);
         if (validateResult.IsFailed)
             return ResultHelpers.CreateFailure(validateResult);
-
         Result<CallbackMessageAggregate> getResult = await this.AggregateRepository.GetLatestVersion(command.CallbackId, cancellationToken);
         Result<CallbackMessageAggregate> callbackMessageAggregateResult =
             DomainServiceHelper.HandleGetAggregateResult(getResult, command.CallbackId, false);
@@ -56,6 +55,7 @@ public class CallbackDomainService : ICallbackDomainService
             (command.Reference,validateResult.Data.estateId, validateResult.Data.merchantId));
         if (stateResult.IsFailed)
             return stateResult;
+        
         return await this.AggregateRepository.SaveChanges(aggregate, cancellationToken);
     }
 

--- a/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
+++ b/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
@@ -5,7 +5,7 @@
 		<DebugType>None</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared" Version="2026.5.5" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
+		<PackageReference Include="Shared" Version="2026.5.6" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
+++ b/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
+++ b/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
@@ -10,8 +10,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-		<PackageReference Include="Shared" Version="2026.5.5" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.5" />
+		<PackageReference Include="Shared" Version="2026.5.6" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
+		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
+++ b/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
@@ -16,12 +16,12 @@
 	  <PackageReference Include="NUnit" Version="4.5.1" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-	  <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build156" />
-	  <PackageReference Include="Shared" Version="2026.5.5" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build352" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build352" />
+	  <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
+	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
+	  <PackageReference Include="Shared" Version="2026.5.6" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler.IntegrationTests/Shared/SharedSteps.cs
+++ b/CallbackHandler.IntegrationTests/Shared/SharedSteps.cs
@@ -72,8 +72,10 @@ namespace CallbackHandler.IntegrationTests.Shared
                 msg.Content = new StringContent(payload, Encoding.UTF8,
                     MediaTypeHeaderValue.Parse("application/json"));
                 var response = await client.SendAsync(msg);
-                response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
                 var content = await response.Content.ReadAsStringAsync();
+                response.StatusCode.ShouldBe(HttpStatusCode.OK, content);
+                
                 CallbackResponse responseData =
                     StringSerialiser.Deserialise<CallbackResponse>(content);
 

--- a/CallbackHandler/CallbackHandler.csproj
+++ b/CallbackHandler/CallbackHandler.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageReference Include="Shared" Version="2026.5.5" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.5" />
+    <PackageReference Include="Shared" Version="2026.5.6" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />

--- a/CallbackHandler/Common/JsonSerializerConfiguration.cs
+++ b/CallbackHandler/Common/JsonSerializerConfiguration.cs
@@ -13,46 +13,6 @@ public static class JsonSerializerConfiguration
         serializerOptions.DictionaryKeyPolicy = defaultOptions.DictionaryKeyPolicy;
         serializerOptions.ReferenceHandler = defaultOptions.ReferenceHandler;
         serializerOptions.WriteIndented = defaultOptions.WriteIndented;
-        serializerOptions.Converters.Add(new UtcDateTimeJsonConverter());
-        serializerOptions.Converters.Add(new NullableUtcDateTimeJsonConverter());
-    }
-
-    private sealed class UtcDateTimeJsonConverter : System.Text.Json.Serialization.JsonConverter<DateTime>
-    {
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var value = reader.GetDateTime();
-            return value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
-        }
-
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime());
-        }
-    }
-
-    private sealed class NullableUtcDateTimeJsonConverter : System.Text.Json.Serialization.JsonConverter<DateTime?>
-    {
-        public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                return null;
-            }
-
-            var value = reader.GetDateTime();
-            return value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
-        }
-
-        public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
-        {
-            if (value.HasValue == false)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-
-            writer.WriteStringValue(value.Value.Kind == DateTimeKind.Utc ? value.Value : value.Value.ToUniversalTime());
-        }
+        serializerOptions.Converters.Add(new DateTimeSpaceConverter());
     }
 }

--- a/CallbackHandler/Handlers/CallbackHandlers.cs
+++ b/CallbackHandler/Handlers/CallbackHandlers.cs
@@ -8,6 +8,7 @@ using SimpleResults;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Shared.Logger;
 using Shared.Serialisation;
 
 namespace CallbackHandler.Handlers;


### PR DESCRIPTION
Updated multiple project files to reference the latest versions of Shared, Shared.DomainDrivenDesign, Shared.EventStore, Shared.Results.Web, SecurityService.Client, SecurityService.IntegrationTesting.Helpers, TransactionProcessor.Client, TransactionProcessor.IntegrationTesting.Helpers, and Shared.IntegrationTesting. This ensures consistency and compatibility across all projects with the most recent dependency updates.

closes #247