### PR TITLE
Centralize NuGet package versions with Directory.Packages.props

### DIFF
--- a/CallbackHander.Testing/CallbackHander.Testing.csproj
+++ b/CallbackHander.Testing/CallbackHander.Testing.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
+++ b/CallbackHandler.BusinessLogic.Tests/CallbackHandler.BusinessLogic.Tests.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shared.EventStore" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.msbuild">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
+++ b/CallbackHandler.BusinessLogic/CallbackHandler.BusinessLogic.csproj
@@ -4,12 +4,12 @@
 	  <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="14.1.0" />
-		<PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
+		<PackageReference Include="MediatR" />
+		<PackageReference Include="SecurityService.Client" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
+		<PackageReference Include="Shared.EventStore" />
+		<PackageReference Include="TransactionProcessor.Client" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\CallbackHandler.CallbackMessageAggregate\CallbackHandler.CallbackMessageAggregate.csproj" />

--- a/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
+++ b/CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj
@@ -5,7 +5,7 @@
 		<DebugType>None</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
+++ b/CallbackHandler.CallbackMessageAggregate.Tests/CallbackHandler.CallbackMessageAggregate.Tests.csproj
@@ -7,19 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shared.EventStore" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.extensibility.core" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	<PackageReference Include="coverlet.msbuild" Version="8.0.0">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
+++ b/CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageAggregate.csproj
@@ -9,9 +9,9 @@
 		<ProjectReference Include="..\CallbackHandlers.Models\CallbackHandlers.Models.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
+		<PackageReference Include="Grpc.Net.Client" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
+		<PackageReference Include="Shared.EventStore" />
 	</ItemGroup>
 </Project>

--- a/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
+++ b/CallbackHandler.IntegrationTests/CallbackHandler.IntegrationTests.csproj
@@ -9,19 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="Reqnroll" Version="3.3.3" />
-	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-	  <PackageReference Include="NUnit" Version="4.5.1" />
-	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-	  <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
-	  <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
+    <PackageReference Include="EventStoreProjections" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="TransactionProcessor.Client" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler.Tests/CallbackHandler.Tests.csproj
+++ b/CallbackHandler.Tests/CallbackHandler.Tests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lamar" Version="15.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Lamar" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CallbackHandler.sln
+++ b/CallbackHandler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31808.319
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11903.348 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CallbackHandler", "CallbackHandler\CallbackHandler.csproj", "{F15F0E96-850C-405D-8BBC-A2141B1449CF}"
 EndProject
@@ -28,6 +28,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CallbackHandler.Tests", "CallbackHandler.Tests\CallbackHandler.Tests.csproj", "{571799A6-F6C2-4BE1-89C8-BA02453C9596}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CallbackHandler.IntegrationTests", "CallbackHandler.IntegrationTests\CallbackHandler.IntegrationTests.csproj", "{C520F9C3-FE40-4939-BDB2-05251B7147E4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A9C2E3D1-6F3B-4C5A-9C8E-111111111111}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/CallbackHandler/CallbackHandler.csproj
+++ b/CallbackHandler/CallbackHandler.csproj
@@ -6,23 +6,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
-    <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
+    <PackageReference Include="Lamar" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Results.Web" />
+    <PackageReference Include="SimpleResults.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallbackHandler/Dockerfile
+++ b/CallbackHandler/Dockerfile
@@ -10,8 +10,10 @@ COPY ["CallbackHandler.CallbackMessageAggregate/CallbackHandler.CallbackMessageA
 COPY ["CallbackHandlers.Models/CallbackHandlers.Models.csproj", "CallbackHandlers.Models/"]
 COPY ["CallbackHandler.CallbackMessage.DomainEvents/CallbackHandler.CallbackMessage.DomainEvents.csproj", "CallbackHandler.CallbackMessage.DomainEvents/"]
 COPY ["CallbackHandler.DataTransferObjects/CallbackHandler.DataTransferObjects.csproj", "CallbackHandler.DataTransferObjects/"]
-RUN dotnet restore "CallbackHandler/CallbackHandler.csproj"
+COPY ["Directory.Packages.props", "."]
 COPY . .
+RUN dotnet restore "CallbackHandler/CallbackHandler.csproj"
+
 WORKDIR "/src/CallbackHandler"
 RUN dotnet build "CallbackHandler.csproj" -c Release -o /app/build
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="EventStoreProjections" Version="2023.12.3" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+    <PackageVersion Include="SecurityService.IntegrationTesting.Helpers" Version="2026.5.1" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="TransactionProcessor.Client" Version="2026.5.2" />
+    <PackageVersion Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.5.2" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Shared.DomainDrivenDesign" Version="2026.5.7" />
+    <PackageVersion Include="Shared.EventStore" Version="2026.5.7" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+    <PackageVersion Include="SimpleResults.AspNetCore" Version="4.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Move all NuGet package version management to Directory.Packages.props, removing explicit versions from .csproj files. Projects now reference packages without specifying versions, ensuring consistency and simplifying dependency updates. The solution file is updated to include the new central props file.

closes #267 